### PR TITLE
Bewegung zwischen Räumen

### DIFF
--- a/src/main/java/org/example/Direction.java
+++ b/src/main/java/org/example/Direction.java
@@ -1,10 +1,10 @@
 package org.example;
 
 public enum Direction {
-    NORTH("norden"),
-    SOUTH("süden"),
-    EAST("osten"),
-    WEST("westen");
+    NORTH("(w) Norden"),
+    SOUTH("(s) Süden"),
+    EAST("(d) Osten"),
+    WEST("(a) Westen");
 
     private final String label;
 

--- a/src/main/java/org/example/Game.java
+++ b/src/main/java/org/example/Game.java
@@ -49,6 +49,10 @@ public class Game {
         return switch (normalized) {
             case "status" -> player.getPlayerStatus().toString();
             case "schauen" -> player.getCurrentRoomDescription();
+            case "w" -> player.move(Direction.NORTH);
+            case "a" -> player.move(Direction.WEST);
+            case "s" -> player.move(Direction.SOUTH);
+            case "d" -> player.move(Direction.EAST);
             case "quit" -> {
                 isStarted = false;
                 yield "Spiel beendet. Auf Wiedersehen!";
@@ -68,7 +72,7 @@ public class Game {
             if ("Unbekannter Befehl".equals(response)) {
                 System.out.println("Falscher Befehl eingegeben. Bitte gib einen gültigen Befehl ein.");
             } else if (!response.isEmpty()) {
-                System.out.println(response);
+                System.out.println(response+"\n");
             }
         }
     }

--- a/src/main/java/org/example/Player.java
+++ b/src/main/java/org/example/Player.java
@@ -2,12 +2,7 @@ package org.example;
 
 public class Player {
     private final PlayerStatus status;
-    private final Room currentRoom;
-
-    public Player() {
-        this.status = new PlayerStatus(100, 100, 10, 0, 8);
-        this.currentRoom = null;
-    }
+    private Room currentRoom;
 
     public Player(Room startRoom) {
         this.status = new PlayerStatus(100, 100, 10, 0, 8);
@@ -24,6 +19,18 @@ public class Player {
 
     public String getCurrentRoomDescription() {
         return currentRoom == null ? "" : currentRoom.toString();
+    }
+
+    public String move(Direction direction) {
+        if (currentRoom == null) {
+            return "";
+        }
+        Room nextRoom = currentRoom.getNextRoom(direction);
+        if (nextRoom == null) {
+            return "Dort ist eine Wand.";
+        }
+        currentRoom = nextRoom;
+        return currentRoom.toString();
     }
 }
 

--- a/src/main/java/org/example/Room.java
+++ b/src/main/java/org/example/Room.java
@@ -1,12 +1,15 @@
 package org.example;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+
 
 public class Room {
     private final String name;
     private final String beschreibung;
-    private final Map<String, Room> exits = new LinkedHashMap<>();
+    private final Map<Direction, Room> exits = new LinkedHashMap<>();
 
     public Room(String name, String beschreibung) {
         this.name = name;
@@ -14,7 +17,11 @@ public class Room {
     }
 
     public void connect(Direction direction, Room target) {
-        exits.put(direction.label(), target);
+        exits.put(direction, target);
+    }
+
+    public Room getNextRoom(Direction direction) {
+        return exits.get(direction);
     }
 
     @Override
@@ -25,7 +32,11 @@ public class Room {
         if (exits.isEmpty()) {
             sb.append("Ausgänge: keine");
         } else {
-            sb.append("Ausgänge: ").append(String.join(", ", exits.keySet()));
+            List<String> directionLabels = new ArrayList<>();
+            for (Direction d : exits.keySet()) {
+                directionLabels.add(d.label());
+            }
+            sb.append("Ausgänge: ").append(String.join(", ", directionLabels));
         }
         return sb.toString();
     }

--- a/src/test/java/org/example/GameTest.java
+++ b/src/test/java/org/example/GameTest.java
@@ -1,6 +1,11 @@
 package org.example;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -37,6 +42,26 @@ public class GameTest {
                 lower.contains("norden") || lower.contains("süden") ||
                 lower.contains("osten") || lower.contains("westen");
         assertTrue(hasName && hasExit && hasExitLabel);
+    }
+
+    private static Stream<Arguments> movementCases() {
+        return Stream.of(
+                Arguments.of("", "w", "Raum: Waffenkammer"),
+                Arguments.of("", "a", "Dort ist eine Wand."),
+                Arguments.of("", "s", "Dort ist eine Wand."),
+                Arguments.of("w", "d", "Raum: Bibliothek")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("movementCases")
+    void processCommand_wasd_parameterized(String pre, String cmd, String expectedContains) {
+        Game game = new Game();
+        for (char c : pre.toCharArray()) {
+            game.processCommand(String.valueOf(c));
+        }
+        String out = game.processCommand(cmd);
+        assertTrue(out.contains(expectedContains));
     }
 }
 

--- a/src/test/java/org/example/PlayerTest.java
+++ b/src/test/java/org/example/PlayerTest.java
@@ -1,0 +1,42 @@
+package org.example;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class PlayerTest {
+
+    @Test
+    void move_returnsNewRoomDescription_onValidExit() {
+        Room start = new Room("Start", "");
+        Room next = new Room("Ziel", "");
+        start.connect(Direction.NORTH, next);
+        Player player = new Player(start);
+
+        String out = player.move(Direction.NORTH);
+
+        assertTrue(out.contains("Raum: Ziel"));
+    }
+
+    @Test
+    void move_returnsWallMessage_onMissingExit() {
+        Room start = new Room("Start", "");
+        Player player = new Player(start);
+
+        String out = player.move(Direction.WEST);
+
+        assertEquals("Dort ist eine Wand.", out);
+    }
+
+    @Test
+    void move_fromNullRoom_returnsEmptyString() {
+        Player player = new Player(null);
+
+        String out = player.move(Direction.NORTH);
+
+        assertEquals("", out);
+    }
+}
+
+

--- a/src/test/java/org/example/RoomTest.java
+++ b/src/test/java/org/example/RoomTest.java
@@ -17,7 +17,7 @@ public class RoomTest {
 
         String out = a.toString().toLowerCase();
         assertTrue(out.contains("ausgänge:"));
-        assertTrue(out.contains(direction.label()));
+        assertTrue(out.contains(direction.label().toLowerCase()));
     }
 
     @Test


### PR DESCRIPTION

Bewegung zwischen Räumen 

Als Spieler möchte ich mich per w/a/s/d bewegen, um den Dungeon zu erkunden.

Gültige Ausgänge: Bewegung klappt und neuer Raum wird bestätigt.
Ungültige Richtung: „Dort ist eine Wand.“



